### PR TITLE
Fix: updates for integration deployment scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ pre-devnet: submodules $(DEVNET_CANNON_PRESTATE_FILES)
 .PHONY: pre-devnet
 
 devnet-up: pre-devnet ## Starts the local devnet
+	./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock \
+		|| make devnet-allocs
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 

--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,6 @@ pre-devnet: submodules $(DEVNET_CANNON_PRESTATE_FILES)
 .PHONY: pre-devnet
 
 devnet-up: pre-devnet ## Starts the local devnet
-	./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock \
-		|| make devnet-allocs
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 
 replace (
 	github.com/babylonlabs-io/babylon => github.com/babylonlabs-io/babylon-private v0.9.0-rc.3.0.20240801001431-74a24c962ce2
-	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67
+	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum/go-ethereum v1.14.7 => github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 
 replace (
 	github.com/babylonlabs-io/babylon => github.com/babylonlabs-io/babylon-private v0.9.0-rc.3.0.20240801001431-74a24c962ce2
-	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49
+	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240821072029-288e883914d5
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum/go-ethereum v1.14.7 => github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 
 replace (
 	github.com/babylonlabs-io/babylon => github.com/babylonlabs-io/babylon-private v0.9.0-rc.3.0.20240801001431-74a24c962ce2
-	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d
+	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum/go-ethereum v1.14.7 => github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 
 replace (
 	github.com/babylonlabs-io/babylon => github.com/babylonlabs-io/babylon-private v0.9.0-rc.3.0.20240801001431-74a24c962ce2
-	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.0.0-20240808170113-a35c696d61b2
+	github.com/babylonlabs-io/finality-gadget => github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20231018212520-f6cde3fc2fa4
 	github.com/ethereum/go-ethereum v1.14.7 => github.com/ethereum-optimism/op-geth v1.101407.0-rc.1.0.20240812224053-8d99ca68bb1a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQh
 github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d h1:UYuC40x3aIMdfzs7Ljj2odjrqB5iM8KjwzO2M0A+JDw=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49 h1:FuOIYF/MyisKfIm9vqerN8jT7eJ2kKTYyopyGrfFc78=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQh
 github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67 h1:ryNIbZiR/gs3lx4lqyKvm0kLjpHgWxqixRMCFjdROfw=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d h1:UYuC40x3aIMdfzs7Ljj2odjrqB5iM8KjwzO2M0A+JDw=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820015242-85727698fe8d/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQh
 github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49 h1:FuOIYF/MyisKfIm9vqerN8jT7eJ2kKTYyopyGrfFc78=
-github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240820173756-934d3c942b49/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240821072029-288e883914d5 h1:Dto9JfYj1yCZPkwC50dTYxIprBBRcYu+S0RG9OrOVeI=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240821072029-288e883914d5/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQh
 github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
-github.com/babylonlabs-io/finality-gadget v0.0.0-20240808170113-a35c696d61b2 h1:ntR4P+jmATTEFqwaKOcA7TapDqIXUuerWRv5fao7eqw=
-github.com/babylonlabs-io/finality-gadget v0.0.0-20240808170113-a35c696d61b2/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67 h1:ryNIbZiR/gs3lx4lqyKvm0kLjpHgWxqixRMCFjdROfw=
+github.com/babylonlabs-io/finality-gadget v0.1.1-0.20240815121858-ee65e0d0fa67/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -360,8 +360,6 @@ func (fi *Finalizer) findLastBtcFinalizedL2Block(
 	}
 
 	lastFinalizedBlockNumber, err := fi.babylonFinalityClient.QueryBlockRangeBabylonFinalized(queryBlocks)
-	fi.log.Debug("QueryBlockRangeBabylonFinalized", "lastFinalizedBlockNumber", lastFinalizedBlockNumber)
-
 	if err != nil {
 		// on CriticalError, the chain will get stuck because
 		// op-e2e/actions/l2_verifier.go will detect it and panic
@@ -374,6 +372,7 @@ func (fi *Finalizer) findLastBtcFinalizedL2Block(
 	}
 
 	if lastFinalizedBlockNumber != nil {
+		fi.log.Debug("QueryBlockRangeBabylonFinalized", "lastFinalizedBlockNumber", *lastFinalizedBlockNumber)
 		res := l2Blocks[*lastFinalizedBlockNumber]
 		return &res
 	}

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -340,16 +340,17 @@ func (fi *Finalizer) findLastBtcFinalizedL2Block(
 			continue
 		}
 
-		queryBlocks = append(queryBlocks, &fgtypes.Block{
+		queryBlock := &fgtypes.Block{
 			BlockHeight:    l2Block.Number,
 			BlockHash:      l2Block.Hash.String(),
 			BlockTimestamp: l2Block.Time,
-		})
+		}
+		queryBlocks = append(queryBlocks, queryBlock)
 		fi.log.Debug(
 			"added block to babylon gadget's query params",
-			"block_height", queryBlocks[i].BlockHeight,
-			"block_hash", queryBlocks[i].BlockHash,
-			"block_timestamp", queryBlocks[i].BlockTimestamp,
+			"block_height", queryBlock.BlockHeight,
+			"block_hash", queryBlock.BlockHash,
+			"block_timestamp", queryBlock.BlockTimestamp,
 		)
 	}
 

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -12,6 +12,9 @@ volumes:
   da_data:
   op_log:
 
+networks:
+  artifacts_localnet:
+    external: true
 
 services:
 
@@ -87,6 +90,9 @@ services:
       - "/entrypoint.sh"
     environment:
       GETH_MINER_RECOMMIT: 100ms
+    networks:
+      - default
+      - artifacts_localnet
 
   op-node:
     depends_on:

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -12,6 +12,10 @@ volumes:
   da_data:
   op_log:
 
+# This is added for Babylon integration deployment scripts
+# TODO: Remove this once we have a better way to do this
+# e.g. update this compose file with the bash script before the op devnet setup
+# and revert it when op devnet down
 networks:
   artifacts_localnet:
     external: true

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -147,6 +147,9 @@ services:
       - "${PWD}/test-jwt-secret.txt:/config/jwt-secret.txt"
       - "${PWD}/../.devnet/rollup.json:/rollup.json"
       - op_log:/op_log
+    networks:
+      - default
+      - artifacts_localnet
 
   op-proposer:
     depends_on:
@@ -177,6 +180,9 @@ services:
       OP_PROPOSER_METRICS_ENABLED: "true"
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
       OP_PROPOSER_RPC_ENABLE_ADMIN: "true"
+    networks:
+      - default
+      - artifacts_localnet
 
   op-batcher:
     depends_on:
@@ -212,6 +218,9 @@ services:
       # uncomment to use blobs
       # (requires L1 Dencun and L2 Ecotone activation first)
       # OP_BATCHER_DATA_AVAILABILITY_TYPE: blobs
+    networks:
+      - default
+      - artifacts_localnet
 
   op-challenger:
     depends_on:

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -180,9 +180,6 @@ services:
       OP_PROPOSER_METRICS_ENABLED: "true"
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
       OP_PROPOSER_RPC_ENABLE_ADMIN: "true"
-    networks:
-      - default
-      - artifacts_localnet
 
   op-batcher:
     depends_on:
@@ -218,9 +215,6 @@ services:
       # uncomment to use blobs
       # (requires L1 Dencun and L2 Ecotone activation first)
       # OP_BATCHER_DATA_AVAILABILITY_TYPE: blobs
-    networks:
-      - default
-      - artifacts_localnet
 
   op-challenger:
     depends_on:

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -62,7 +62,7 @@
   "faultGameWithdrawalDelay": 604800,
   "preimageOracleMinProposalSize": 10000,
   "preimageOracleChallengePeriod": 120,
-  "babylonFinalityGadgetRpc": "http://finality-gadget:50051",
+  "babylonFinalityGadgetRpc": "finality-gadget:50051",
   "proofMaturityDelaySeconds": 12,
   "disputeGameFinalityDelaySeconds": 6,
   "respectedGameType": 254,

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -62,7 +62,7 @@
   "faultGameWithdrawalDelay": 604800,
   "preimageOracleMinProposalSize": 10000,
   "preimageOracleChallengePeriod": 120,
-  "babylonFinalityGadgetRpc": "http://localhost:8080",
+  "babylonFinalityGadgetRpc": "http://finality-gadget:50051",
   "proofMaturityDelaySeconds": 12,
   "disputeGameFinalityDelaySeconds": 6,
   "respectedGameType": 254,


### PR DESCRIPTION
## Summary

This PR updated the config files and codes to fix the op devnet setup issues in the integration deployment scripts.
 
* The scheme `http://` is not needed for `babylonFinalityGadgetRpc` in the `devnetL1-template.json`
* Add `networks` for the service `l2` and `op-node` to make sure the service `finality-gadget` under the network `artifacts_localnet` can access each other
* Fix the logging panic issue: `index out of range`

## Test Plan

```
make lint-go
cd op-node
make test
```

Test it by running the integration deployment scripts:

```
git clone git@github.com:babylonlabs-io/babylon-integration-deployment.git
cd babylon-integration-deployment
git submodule init && git submodule update

make start-deployment-finality-gadget-integration-op-l2-demo
```