### PR TITLE
chore: update L1 settings for local devnet

### DIFF
--- a/ops-bedrock/l1-lighthouse.Dockerfile
+++ b/ops-bedrock/l1-lighthouse.Dockerfile
@@ -1,4 +1,4 @@
-FROM sigp/lighthouse:v5.2.1
+FROM sigp/lighthouse:v5.3.0
 
 COPY l1-lighthouse-bn-entrypoint.sh /entrypoint-bn.sh
 COPY l1-lighthouse-vc-entrypoint.sh /entrypoint-vc.sh

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -15,7 +15,7 @@
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
   "l2GenesisBlockGasLimit": "0x1c9c380",
-  "l1BlockTime": 6,
+  "l1BlockTime": 12,
   "baseFeeVaultRecipient": "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
   "l1FeeVaultRecipient": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
   "sequencerFeeVaultRecipient": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",


### PR DESCRIPTION
## Summary

This PR updates settings for local devnet:
* L1 block time: `12` which is used for both Sepolia and Mainnet.
* Upgrade lighthouse version to `v5.3.0` which has this [RP](https://github.com/sigp/lighthouse/pull/6014) that drop skip too large condition for liveness safety.