### PR TITLE
fix: missing comma in `config.sh`

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -142,7 +142,7 @@ cat << EOL >> tmp_config.json
   "faultGameWithdrawalDelay": 600,
 
   "preimageOracleMinProposalSize": 1800000,
-  "preimageOracleChallengePeriod": 300
+  "preimageOracleChallengePeriod": 300,
 
   "babylonFinalityGadgetRpc": "$BBN_FINALITY_GADGET_RPC"
 }


### PR DESCRIPTION
This PR fixes the missing comma in the `config.sh` script.